### PR TITLE
Fix Faraday with default (Net::HTTP) adapter

### DIFF
--- a/certified.rb
+++ b/certified.rb
@@ -10,3 +10,11 @@ Net::HTTP.class_eval do
   end
 end
 
+OpenSSL::X509::Store.class_eval do
+  alias _set_default_paths set_default_paths
+
+  def set_default_paths
+    self._set_default_paths
+    self.add_file "#{File.dirname(__FILE__)}/certs/ca-bundle.crt"
+  end
+end


### PR DESCRIPTION
Besides ca_file Faraday seems to set a `cert_store` to `Net::HTTP`, and it seems to override the setting from ca_file.
