### PR TITLE
Use URI.open

### DIFF
--- a/bin/certified-update
+++ b/bin/certified-update
@@ -10,7 +10,7 @@ puts "Updating ca-bundle from #{CERT_BUNDLE_URL}"
 
 cert_path = Pathname.new File.expand_path('../../certs', __FILE__)
 
-open(CERT_BUNDLE_URL) do |remote_file|
+URI.open(CERT_BUNDLE_URL) do |remote_file|
   File.open(cert_path + 'ca-bundle.crt', 'w+') do |cert_file|
     remote_file.each_line do |line|
       cert_file << line


### PR DESCRIPTION
calling URI.open via Kernel#open is deprecated, call URI.open explicitly instead
https://bugs.ruby-lang.org/issues/19630
https://bugs.ruby-lang.org/issues/15893