### PR TITLE
use URI#parse/open instead of Kernel#open

### DIFF
--- a/bin/certified-update
+++ b/bin/certified-update
@@ -4,18 +4,18 @@ require 'open-uri'
 require 'pathname'
 require 'certified'
 
-CERT_BUNDLE_URL = 'https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt'
+CERT_BUNDLE_URL = 'https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt'.freeze
 
 puts "Updating ca-bundle from #{CERT_BUNDLE_URL}"
 
-cert_path = Pathname.new File.expand_path('../../certs', __FILE__)
+cert_path = Pathname.new File.expand_path('../certs', __dir__)
 
-open(CERT_BUNDLE_URL) do |remote_file|
-  File.open(cert_path + 'ca-bundle.crt', 'w+') do |cert_file|
+URI.parse(CERT_BUNDLE_URL).open do |remote_file|
+  File.open("#{cert_path}ca-bundle.crt", 'w+') do |cert_file|
     remote_file.each_line do |line|
       cert_file << line
     end
   end
 end
 
-puts "Certificate bundle updated. Remember to do this regularly!"
+puts 'Certificate bundle updated. Remember to do this regularly!'


### PR DESCRIPTION
Kernel#open was removed in Ruby 3.x